### PR TITLE
linux-variscite_5.15.bb: Fix build with gcc-13

### DIFF
--- a/conf/machine/variscite.inc
+++ b/conf/machine/variscite.inc
@@ -17,7 +17,8 @@ WKS_FILE:mx8-nxp-bsp = "imx-imx-boot-singlepart.wks.in"
 WKS_FILE:mx9-nxp-bsp = "imx-imx-boot-singlepart.wks.in"
 
 # Enable optee on iMX8 BSPs
-MACHINE_FEATURES:append:use-nxp-bsp = " optee"
+MACHINE_FEATURES:append:mx8-nxp-bsp:use-nxp-bsp = " optee"
+MACHINE_FEATURES:append:mx9-nxp-bsp:use-nxp-bsp = " optee"
 
 # Set a more generic tuning for code reuse across parts
 DEFAULTTUNE:mx8-nxp-bsp:fslc     ?= "armv8a-crc-crypto"

--- a/conf/machine/variscite_ubi.inc
+++ b/conf/machine/variscite_ubi.inc
@@ -1,11 +1,11 @@
 # UBIFS for Variscite 0.5GB NAND flash
 # erase block size of 128KiB
-export MKUBIFS_ARGS_128kbpeb = " -m 2048 -e 124KiB -c 3965 "
-export UBINIZE_ARGS_128kbpeb = " -m 2048 -p 128KiB -s 2048 "
+MKUBIFS_ARGS_128kbpeb = " -m 2048 -e 124KiB -c 3965 "
+UBINIZE_ARGS_128kbpeb = " -m 2048 -p 128KiB -s 2048 "
 
 # erase block size of 256KiB
-export MKUBIFS_ARGS_256kbpeb = " -m 4096 -e 248KiB -c 2000 "
-export UBINIZE_ARGS_256kbpeb = " -m 4096 -p 256KiB -s 4096 "
+MKUBIFS_ARGS_256kbpeb = " -m 4096 -e 248KiB -c 2000 "
+UBINIZE_ARGS_256kbpeb = " -m 4096 -p 256KiB -s 4096 "
 
 # UBIFS for Variscite 1GB NAND flash
 # erase block size of 128KiB

--- a/recipes-kernel/linux/linux-variscite/0001-Match-function-return-types-for-_QuerySignal.patch
+++ b/recipes-kernel/linux/linux-variscite/0001-Match-function-return-types-for-_QuerySignal.patch
@@ -1,0 +1,44 @@
+From 4fc937d65b74815b7e11d02be995328605d7ac88 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Tue, 21 Nov 2023 14:33:51 -0800
+Subject: [PATCH] Match function return types for _QuerySignal
+
+Newer compiler e.g. gcc 13 finds this enum mismatch error. Its already
+fixed in 6.4 vivante GPU kernel driver [1]
+
+Fixes
+drivers/mxc/gpu-viv/hal/os/linux/kernel/gc_hal_kernel_os.c:5875:1: error: conflicting types for '_QuerySignal' due to enum/integer mismatch; have 'gceST
+ATUS(struct _gckOS *, void *)' {aka 'enum _gceSTATUS(struct _gckOS *, void *)'} [-Werror=enum-int-mismatch]
+ 5875 | _QuerySignal(
+      | ^~~~~~~~~~~~
+In file included from /mnt/b/yoe/master/build/tmp/work-shared/imx6ul-var-dart/kernel-source/drivers/mxc/gpu-viv/hal/os/linux/kernel/gc_hal_kernel_os.c:56:
+/mnt/b/yoe/master/build/tmp/work-shared/imx6ul-var-dart/kernel-source/drivers/mxc/gpu-viv/hal/os/linux/kernel/gc_hal_kernel_linux.h:322:1: note: previous declaration of '_QuerySignal' with type 'gctBOOL(struct _gckOS *, vo
+id *)' {aka 'int(struct _gckOS *, void *)'}
+  322 | _QuerySignal(
+      | ^~~~~~~~~~~~
+cc1: all warnings being treated as errors
+
+[1] https://github.com/Freescale/kernel-module-imx-gpu-viv/commit/6bd4a7248992ec270ced9c09d9e90e0c3b048626#diff-f76e88478e6e50534d0ae4353d9594d022171b8d22863e635b0a8611abd24e0b
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ drivers/mxc/gpu-viv/hal/os/linux/kernel/gc_hal_kernel_linux.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/mxc/gpu-viv/hal/os/linux/kernel/gc_hal_kernel_linux.h b/drivers/mxc/gpu-viv/hal/os/linux/kernel/gc_hal_kernel_linux.h
+index a436edb11d9a..43beb7a06f73 100644
+--- a/drivers/mxc/gpu-viv/hal/os/linux/kernel/gc_hal_kernel_linux.h
++++ b/drivers/mxc/gpu-viv/hal/os/linux/kernel/gc_hal_kernel_linux.h
+@@ -318,7 +318,7 @@ _ConvertLogical2Physical(
+     OUT gctPHYS_ADDR_T * Physical
+     );
+ 
+-gctBOOL
++gceSTATUS
+ _QuerySignal(
+     IN gckOS Os,
+     IN gctSIGNAL Signal
+-- 
+2.43.0
+

--- a/recipes-kernel/linux/linux-variscite/0001-ata-ahci-fix-enum-constants-for-gcc-13.patch
+++ b/recipes-kernel/linux/linux-variscite/0001-ata-ahci-fix-enum-constants-for-gcc-13.patch
@@ -1,0 +1,370 @@
+From dcbbee35bac153eee0818dabb1ab38bc4f8eb527 Mon Sep 17 00:00:00 2001
+From: Arnd Bergmann <arnd@arndb.de>
+Date: Thu, 8 Jun 2023 22:34:57 +0100
+Subject: [PATCH] ata: ahci: fix enum constants for gcc-13
+
+commit f07788079f515ca4a681c5f595bdad19cfbd7b1d upstream.
+
+gcc-13 slightly changes the type of constant expressions that are defined
+in an enum, which triggers a compile time sanity check in libata:
+
+linux/drivers/ata/libahci.c: In function 'ahci_led_store':
+linux/include/linux/compiler_types.h:357:45: error: call to '__compiletime_assert_302' declared with attribute error: BUILD_BUG_ON failed: sizeof(_s) > sizeof(long)
+357 | _compiletime_assert(condition, msg, __compiletime_assert_, __COUNTER__)
+
+The new behavior is that sizeof() returns the same value for the
+constant as it does for the enum type, which is generally more sensible
+and consistent.
+
+The problem in libata is that it contains a single enum definition for
+lots of unrelated constants, some of which are large positive (unsigned)
+integers like 0xffffffff, while others like (1<<31) are interpreted as
+negative integers, and this forces the enum type to become 64 bit wide
+even though most constants would still fit into a signed 32-bit 'int'.
+
+Fix this by changing the entire enum definition to use BIT(x) in place
+of (1<<x), which results in all values being seen as 'unsigned' and
+fitting into an unsigned 32-bit type.
+
+Upstream-Status: Backport [https://lore.kernel.org/lkml/20221203105425.180641-1-arnd@kernel.org/]
+Link: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107917
+Link: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107405
+Reported-by: Luis Machado <luis.machado@arm.com>
+Cc: linux-ide@vger.kernel.org
+Cc: Damien Le Moal <damien.lemoal@opensource.wdc.com>
+Cc: stable@vger.kernel.org
+Cc: Randy Dunlap <rdunlap@infradead.org>
+Signed-off-by: Arnd Bergmann <arnd@arndb.de>
+Tested-by: Luis Machado <luis.machado@arm.com>
+Signed-off-by: Damien Le Moal <damien.lemoal@opensource.wdc.com>
+[ Modified to account for slight differences in the enum contents in the 5.15.y tree. ]
+Signed-off-by: Paul Barker <paul.barker@sancloud.com>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/ata/ahci.h | 245 +++++++++++++++++++++++----------------------
+ 1 file changed, 123 insertions(+), 122 deletions(-)
+
+diff --git a/drivers/ata/ahci.h b/drivers/ata/ahci.h
+index 60ae707a88cc..dcc2d92cf6b6 100644
+--- a/drivers/ata/ahci.h
++++ b/drivers/ata/ahci.h
+@@ -24,6 +24,7 @@
+ #include <linux/libata.h>
+ #include <linux/phy/phy.h>
+ #include <linux/regulator/consumer.h>
++#include <linux/bits.h>
+ 
+ /* Enclosure Management Control */
+ #define EM_CTRL_MSG_TYPE              0x000f0000
+@@ -54,12 +55,12 @@ enum {
+ 	AHCI_PORT_PRIV_FBS_DMA_SZ	= AHCI_CMD_SLOT_SZ +
+ 					  AHCI_CMD_TBL_AR_SZ +
+ 					  (AHCI_RX_FIS_SZ * 16),
+-	AHCI_IRQ_ON_SG		= (1 << 31),
+-	AHCI_CMD_ATAPI		= (1 << 5),
+-	AHCI_CMD_WRITE		= (1 << 6),
+-	AHCI_CMD_PREFETCH	= (1 << 7),
+-	AHCI_CMD_RESET		= (1 << 8),
+-	AHCI_CMD_CLR_BUSY	= (1 << 10),
++	AHCI_IRQ_ON_SG		= BIT(31),
++	AHCI_CMD_ATAPI		= BIT(5),
++	AHCI_CMD_WRITE		= BIT(6),
++	AHCI_CMD_PREFETCH	= BIT(7),
++	AHCI_CMD_RESET		= BIT(8),
++	AHCI_CMD_CLR_BUSY	= BIT(10),
+ 
+ 	RX_FIS_PIO_SETUP	= 0x20,	/* offset of PIO Setup FIS data */
+ 	RX_FIS_D2H_REG		= 0x40,	/* offset of D2H Register FIS data */
+@@ -77,37 +78,37 @@ enum {
+ 	HOST_CAP2		= 0x24, /* host capabilities, extended */
+ 
+ 	/* HOST_CTL bits */
+-	HOST_RESET		= (1 << 0),  /* reset controller; self-clear */
+-	HOST_IRQ_EN		= (1 << 1),  /* global IRQ enable */
+-	HOST_MRSM		= (1 << 2),  /* MSI Revert to Single Message */
+-	HOST_AHCI_EN		= (1 << 31), /* AHCI enabled */
++	HOST_RESET		= BIT(0),  /* reset controller; self-clear */
++	HOST_IRQ_EN		= BIT(1),  /* global IRQ enable */
++	HOST_MRSM		= BIT(2),  /* MSI Revert to Single Message */
++	HOST_AHCI_EN		= BIT(31), /* AHCI enabled */
+ 
+ 	/* HOST_CAP bits */
+-	HOST_CAP_SXS		= (1 << 5),  /* Supports External SATA */
+-	HOST_CAP_EMS		= (1 << 6),  /* Enclosure Management support */
+-	HOST_CAP_CCC		= (1 << 7),  /* Command Completion Coalescing */
+-	HOST_CAP_PART		= (1 << 13), /* Partial state capable */
+-	HOST_CAP_SSC		= (1 << 14), /* Slumber state capable */
+-	HOST_CAP_PIO_MULTI	= (1 << 15), /* PIO multiple DRQ support */
+-	HOST_CAP_FBS		= (1 << 16), /* FIS-based switching support */
+-	HOST_CAP_PMP		= (1 << 17), /* Port Multiplier support */
+-	HOST_CAP_ONLY		= (1 << 18), /* Supports AHCI mode only */
+-	HOST_CAP_CLO		= (1 << 24), /* Command List Override support */
+-	HOST_CAP_LED		= (1 << 25), /* Supports activity LED */
+-	HOST_CAP_ALPM		= (1 << 26), /* Aggressive Link PM support */
+-	HOST_CAP_SSS		= (1 << 27), /* Staggered Spin-up */
+-	HOST_CAP_MPS		= (1 << 28), /* Mechanical presence switch */
+-	HOST_CAP_SNTF		= (1 << 29), /* SNotification register */
+-	HOST_CAP_NCQ		= (1 << 30), /* Native Command Queueing */
+-	HOST_CAP_64		= (1 << 31), /* PCI DAC (64-bit DMA) support */
++	HOST_CAP_SXS		= BIT(5),  /* Supports External SATA */
++	HOST_CAP_EMS		= BIT(6),  /* Enclosure Management support */
++	HOST_CAP_CCC		= BIT(7),  /* Command Completion Coalescing */
++	HOST_CAP_PART		= BIT(13), /* Partial state capable */
++	HOST_CAP_SSC		= BIT(14), /* Slumber state capable */
++	HOST_CAP_PIO_MULTI	= BIT(15), /* PIO multiple DRQ support */
++	HOST_CAP_FBS		= BIT(16), /* FIS-based switching support */
++	HOST_CAP_PMP		= BIT(17), /* Port Multiplier support */
++	HOST_CAP_ONLY		= BIT(18), /* Supports AHCI mode only */
++	HOST_CAP_CLO		= BIT(24), /* Command List Override support */
++	HOST_CAP_LED		= BIT(25), /* Supports activity LED */
++	HOST_CAP_ALPM		= BIT(26), /* Aggressive Link PM support */
++	HOST_CAP_SSS		= BIT(27), /* Staggered Spin-up */
++	HOST_CAP_MPS		= BIT(28), /* Mechanical presence switch */
++	HOST_CAP_SNTF		= BIT(29), /* SNotification register */
++	HOST_CAP_NCQ		= BIT(30), /* Native Command Queueing */
++	HOST_CAP_64		= BIT(31), /* PCI DAC (64-bit DMA) support */
+ 
+ 	/* HOST_CAP2 bits */
+-	HOST_CAP2_BOH		= (1 << 0),  /* BIOS/OS handoff supported */
+-	HOST_CAP2_NVMHCI	= (1 << 1),  /* NVMHCI supported */
+-	HOST_CAP2_APST		= (1 << 2),  /* Automatic partial to slumber */
+-	HOST_CAP2_SDS		= (1 << 3),  /* Support device sleep */
+-	HOST_CAP2_SADM		= (1 << 4),  /* Support aggressive DevSlp */
+-	HOST_CAP2_DESO		= (1 << 5),  /* DevSlp from slumber only */
++	HOST_CAP2_BOH		= BIT(0),  /* BIOS/OS handoff supported */
++	HOST_CAP2_NVMHCI	= BIT(1),  /* NVMHCI supported */
++	HOST_CAP2_APST		= BIT(2),  /* Automatic partial to slumber */
++	HOST_CAP2_SDS		= BIT(3),  /* Support device sleep */
++	HOST_CAP2_SADM		= BIT(4),  /* Support aggressive DevSlp */
++	HOST_CAP2_DESO		= BIT(5),  /* DevSlp from slumber only */
+ 
+ 	/* registers for each SATA port */
+ 	PORT_LST_ADDR		= 0x00, /* command list DMA addr */
+@@ -129,24 +130,24 @@ enum {
+ 	PORT_DEVSLP		= 0x44, /* device sleep */
+ 
+ 	/* PORT_IRQ_{STAT,MASK} bits */
+-	PORT_IRQ_COLD_PRES	= (1 << 31), /* cold presence detect */
+-	PORT_IRQ_TF_ERR		= (1 << 30), /* task file error */
+-	PORT_IRQ_HBUS_ERR	= (1 << 29), /* host bus fatal error */
+-	PORT_IRQ_HBUS_DATA_ERR	= (1 << 28), /* host bus data error */
+-	PORT_IRQ_IF_ERR		= (1 << 27), /* interface fatal error */
+-	PORT_IRQ_IF_NONFATAL	= (1 << 26), /* interface non-fatal error */
+-	PORT_IRQ_OVERFLOW	= (1 << 24), /* xfer exhausted available S/G */
+-	PORT_IRQ_BAD_PMP	= (1 << 23), /* incorrect port multiplier */
+-
+-	PORT_IRQ_PHYRDY		= (1 << 22), /* PhyRdy changed */
+-	PORT_IRQ_DEV_ILCK	= (1 << 7), /* device interlock */
+-	PORT_IRQ_CONNECT	= (1 << 6), /* port connect change status */
+-	PORT_IRQ_SG_DONE	= (1 << 5), /* descriptor processed */
+-	PORT_IRQ_UNK_FIS	= (1 << 4), /* unknown FIS rx'd */
+-	PORT_IRQ_SDB_FIS	= (1 << 3), /* Set Device Bits FIS rx'd */
+-	PORT_IRQ_DMAS_FIS	= (1 << 2), /* DMA Setup FIS rx'd */
+-	PORT_IRQ_PIOS_FIS	= (1 << 1), /* PIO Setup FIS rx'd */
+-	PORT_IRQ_D2H_REG_FIS	= (1 << 0), /* D2H Register FIS rx'd */
++	PORT_IRQ_COLD_PRES	= BIT(31), /* cold presence detect */
++	PORT_IRQ_TF_ERR		= BIT(30), /* task file error */
++	PORT_IRQ_HBUS_ERR	= BIT(29), /* host bus fatal error */
++	PORT_IRQ_HBUS_DATA_ERR	= BIT(28), /* host bus data error */
++	PORT_IRQ_IF_ERR		= BIT(27), /* interface fatal error */
++	PORT_IRQ_IF_NONFATAL	= BIT(26), /* interface non-fatal error */
++	PORT_IRQ_OVERFLOW	= BIT(24), /* xfer exhausted available S/G */
++	PORT_IRQ_BAD_PMP	= BIT(23), /* incorrect port multiplier */
++
++	PORT_IRQ_PHYRDY		= BIT(22), /* PhyRdy changed */
++	PORT_IRQ_DEV_ILCK	= BIT(7),  /* device interlock */
++	PORT_IRQ_CONNECT	= BIT(6),  /* port connect change status */
++	PORT_IRQ_SG_DONE	= BIT(5),  /* descriptor processed */
++	PORT_IRQ_UNK_FIS	= BIT(4),  /* unknown FIS rx'd */
++	PORT_IRQ_SDB_FIS	= BIT(3),  /* Set Device Bits FIS rx'd */
++	PORT_IRQ_DMAS_FIS	= BIT(2),  /* DMA Setup FIS rx'd */
++	PORT_IRQ_PIOS_FIS	= BIT(1),  /* PIO Setup FIS rx'd */
++	PORT_IRQ_D2H_REG_FIS	= BIT(0),  /* D2H Register FIS rx'd */
+ 
+ 	PORT_IRQ_FREEZE		= PORT_IRQ_HBUS_ERR |
+ 				  PORT_IRQ_IF_ERR |
+@@ -162,34 +163,34 @@ enum {
+ 				  PORT_IRQ_PIOS_FIS | PORT_IRQ_D2H_REG_FIS,
+ 
+ 	/* PORT_CMD bits */
+-	PORT_CMD_ASP		= (1 << 27), /* Aggressive Slumber/Partial */
+-	PORT_CMD_ALPE		= (1 << 26), /* Aggressive Link PM enable */
+-	PORT_CMD_ATAPI		= (1 << 24), /* Device is ATAPI */
+-	PORT_CMD_FBSCP		= (1 << 22), /* FBS Capable Port */
+-	PORT_CMD_ESP		= (1 << 21), /* External Sata Port */
+-	PORT_CMD_HPCP		= (1 << 18), /* HotPlug Capable Port */
+-	PORT_CMD_PMP		= (1 << 17), /* PMP attached */
+-	PORT_CMD_LIST_ON	= (1 << 15), /* cmd list DMA engine running */
+-	PORT_CMD_FIS_ON		= (1 << 14), /* FIS DMA engine running */
+-	PORT_CMD_FIS_RX		= (1 << 4), /* Enable FIS receive DMA engine */
+-	PORT_CMD_CLO		= (1 << 3), /* Command list override */
+-	PORT_CMD_POWER_ON	= (1 << 2), /* Power up device */
+-	PORT_CMD_SPIN_UP	= (1 << 1), /* Spin up device */
+-	PORT_CMD_START		= (1 << 0), /* Enable port DMA engine */
+-
+-	PORT_CMD_ICC_MASK	= (0xf << 28), /* i/f ICC state mask */
+-	PORT_CMD_ICC_ACTIVE	= (0x1 << 28), /* Put i/f in active state */
+-	PORT_CMD_ICC_PARTIAL	= (0x2 << 28), /* Put i/f in partial state */
+-	PORT_CMD_ICC_SLUMBER	= (0x6 << 28), /* Put i/f in slumber state */
++	PORT_CMD_ASP		= BIT(27), /* Aggressive Slumber/Partial */
++	PORT_CMD_ALPE		= BIT(26), /* Aggressive Link PM enable */
++	PORT_CMD_ATAPI		= BIT(24), /* Device is ATAPI */
++	PORT_CMD_FBSCP		= BIT(22), /* FBS Capable Port */
++	PORT_CMD_ESP		= BIT(21), /* External Sata Port */
++	PORT_CMD_HPCP		= BIT(18), /* HotPlug Capable Port */
++	PORT_CMD_PMP		= BIT(17), /* PMP attached */
++	PORT_CMD_LIST_ON	= BIT(15), /* cmd list DMA engine running */
++	PORT_CMD_FIS_ON		= BIT(14), /* FIS DMA engine running */
++	PORT_CMD_FIS_RX		= BIT(4),  /* Enable FIS receive DMA engine */
++	PORT_CMD_CLO		= BIT(3),  /* Command list override */
++	PORT_CMD_POWER_ON	= BIT(2),  /* Power up device */
++	PORT_CMD_SPIN_UP	= BIT(1),  /* Spin up device */
++	PORT_CMD_START		= BIT(0),  /* Enable port DMA engine */
++
++	PORT_CMD_ICC_MASK	= (0xfu << 28), /* i/f ICC state mask */
++	PORT_CMD_ICC_ACTIVE	= (0x1u << 28), /* Put i/f in active state */
++	PORT_CMD_ICC_PARTIAL	= (0x2u << 28), /* Put i/f in partial state */
++	PORT_CMD_ICC_SLUMBER	= (0x6u << 28), /* Put i/f in slumber state */
+ 
+ 	/* PORT_FBS bits */
+ 	PORT_FBS_DWE_OFFSET	= 16, /* FBS device with error offset */
+ 	PORT_FBS_ADO_OFFSET	= 12, /* FBS active dev optimization offset */
+ 	PORT_FBS_DEV_OFFSET	= 8,  /* FBS device to issue offset */
+ 	PORT_FBS_DEV_MASK	= (0xf << PORT_FBS_DEV_OFFSET),  /* FBS.DEV */
+-	PORT_FBS_SDE		= (1 << 2), /* FBS single device error */
+-	PORT_FBS_DEC		= (1 << 1), /* FBS device error clear */
+-	PORT_FBS_EN		= (1 << 0), /* Enable FBS */
++	PORT_FBS_SDE		= BIT(2), /* FBS single device error */
++	PORT_FBS_DEC		= BIT(1), /* FBS device error clear */
++	PORT_FBS_EN		= BIT(0), /* Enable FBS */
+ 
+ 	/* PORT_DEVSLP bits */
+ 	PORT_DEVSLP_DM_OFFSET	= 25,             /* DITO multiplier offset */
+@@ -197,52 +198,52 @@ enum {
+ 	PORT_DEVSLP_DITO_OFFSET	= 15,             /* DITO offset */
+ 	PORT_DEVSLP_MDAT_OFFSET	= 10,             /* Minimum assertion time */
+ 	PORT_DEVSLP_DETO_OFFSET	= 2,              /* DevSlp exit timeout */
+-	PORT_DEVSLP_DSP		= (1 << 1),       /* DevSlp present */
+-	PORT_DEVSLP_ADSE	= (1 << 0),       /* Aggressive DevSlp enable */
++	PORT_DEVSLP_DSP		= BIT(1),         /* DevSlp present */
++	PORT_DEVSLP_ADSE	= BIT(0),         /* Aggressive DevSlp enable */
+ 
+ 	/* hpriv->flags bits */
+ 
+ #define AHCI_HFLAGS(flags)		.private_data	= (void *)(flags)
+ 
+-	AHCI_HFLAG_NO_NCQ		= (1 << 0),
+-	AHCI_HFLAG_IGN_IRQ_IF_ERR	= (1 << 1), /* ignore IRQ_IF_ERR */
+-	AHCI_HFLAG_IGN_SERR_INTERNAL	= (1 << 2), /* ignore SERR_INTERNAL */
+-	AHCI_HFLAG_32BIT_ONLY		= (1 << 3), /* force 32bit */
+-	AHCI_HFLAG_MV_PATA		= (1 << 4), /* PATA port */
+-	AHCI_HFLAG_NO_MSI		= (1 << 5), /* no PCI MSI */
+-	AHCI_HFLAG_NO_PMP		= (1 << 6), /* no PMP */
+-	AHCI_HFLAG_SECT255		= (1 << 8), /* max 255 sectors */
+-	AHCI_HFLAG_YES_NCQ		= (1 << 9), /* force NCQ cap on */
+-	AHCI_HFLAG_NO_SUSPEND		= (1 << 10), /* don't suspend */
+-	AHCI_HFLAG_SRST_TOUT_IS_OFFLINE	= (1 << 11), /* treat SRST timeout as
+-							link offline */
+-	AHCI_HFLAG_NO_SNTF		= (1 << 12), /* no sntf */
+-	AHCI_HFLAG_NO_FPDMA_AA		= (1 << 13), /* no FPDMA AA */
+-	AHCI_HFLAG_YES_FBS		= (1 << 14), /* force FBS cap on */
+-	AHCI_HFLAG_DELAY_ENGINE		= (1 << 15), /* do not start engine on
+-						        port start (wait until
+-						        error-handling stage) */
+-	AHCI_HFLAG_NO_DEVSLP		= (1 << 17), /* no device sleep */
+-	AHCI_HFLAG_NO_FBS		= (1 << 18), /* no FBS */
++	AHCI_HFLAG_NO_NCQ		= BIT(0),
++	AHCI_HFLAG_IGN_IRQ_IF_ERR	= BIT(1), /* ignore IRQ_IF_ERR */
++	AHCI_HFLAG_IGN_SERR_INTERNAL	= BIT(2), /* ignore SERR_INTERNAL */
++	AHCI_HFLAG_32BIT_ONLY		= BIT(3), /* force 32bit */
++	AHCI_HFLAG_MV_PATA		= BIT(4), /* PATA port */
++	AHCI_HFLAG_NO_MSI		= BIT(5), /* no PCI MSI */
++	AHCI_HFLAG_NO_PMP		= BIT(6), /* no PMP */
++	AHCI_HFLAG_SECT255		= BIT(8), /* max 255 sectors */
++	AHCI_HFLAG_YES_NCQ		= BIT(9), /* force NCQ cap on */
++	AHCI_HFLAG_NO_SUSPEND		= BIT(10), /* don't suspend */
++	AHCI_HFLAG_SRST_TOUT_IS_OFFLINE	= BIT(11), /* treat SRST timeout as
++						      link offline */
++	AHCI_HFLAG_NO_SNTF		= BIT(12), /* no sntf */
++	AHCI_HFLAG_NO_FPDMA_AA		= BIT(13), /* no FPDMA AA */
++	AHCI_HFLAG_YES_FBS		= BIT(14), /* force FBS cap on */
++	AHCI_HFLAG_DELAY_ENGINE		= BIT(15), /* do not start engine on
++						      port start (wait until
++						      error-handling stage) */
++	AHCI_HFLAG_NO_DEVSLP		= BIT(17), /* no device sleep */
++	AHCI_HFLAG_NO_FBS		= BIT(18), /* no FBS */
+ 
+ #ifdef CONFIG_PCI_MSI
+-	AHCI_HFLAG_MULTI_MSI		= (1 << 20), /* per-port MSI(-X) */
++	AHCI_HFLAG_MULTI_MSI		= BIT(20), /* per-port MSI(-X) */
+ #else
+ 	/* compile out MSI infrastructure */
+ 	AHCI_HFLAG_MULTI_MSI		= 0,
+ #endif
+-	AHCI_HFLAG_WAKE_BEFORE_STOP	= (1 << 22), /* wake before DMA stop */
+-	AHCI_HFLAG_YES_ALPM		= (1 << 23), /* force ALPM cap on */
+-	AHCI_HFLAG_NO_WRITE_TO_RO	= (1 << 24), /* don't write to read
+-							only registers */
+-	AHCI_HFLAG_IS_MOBILE		= (1 << 25), /* mobile chipset, use
+-							SATA_MOBILE_LPM_POLICY
+-							as default lpm_policy */
+-	AHCI_HFLAG_SUSPEND_PHYS		= (1 << 26), /* handle PHYs during
+-							suspend/resume */
+-	AHCI_HFLAG_IGN_NOTSUPP_POWER_ON	= (1 << 27), /* ignore -EOPNOTSUPP
+-							from phy_power_on() */
+-	AHCI_HFLAG_NO_SXS		= (1 << 28), /* SXS not supported */
++	AHCI_HFLAG_WAKE_BEFORE_STOP	= BIT(22), /* wake before DMA stop */
++	AHCI_HFLAG_YES_ALPM		= BIT(23), /* force ALPM cap on */
++	AHCI_HFLAG_NO_WRITE_TO_RO	= BIT(24), /* don't write to read
++						      only registers */
++	AHCI_HFLAG_IS_MOBILE            = BIT(25), /* mobile chipset, use
++						      SATA_MOBILE_LPM_POLICY
++						      as default lpm_policy */
++	AHCI_HFLAG_SUSPEND_PHYS		= BIT(26), /* handle PHYs during
++						      suspend/resume */
++	AHCI_HFLAG_IGN_NOTSUPP_POWER_ON	= BIT(27), /* ignore -EOPNOTSUPP
++						      from phy_power_on() */
++	AHCI_HFLAG_NO_SXS		= BIT(28), /* SXS not supported */
+ 
+ 	/* ap->flags bits */
+ 
+@@ -258,22 +259,22 @@ enum {
+ 	EM_MAX_RETRY			= 5,
+ 
+ 	/* em_ctl bits */
+-	EM_CTL_RST		= (1 << 9), /* Reset */
+-	EM_CTL_TM		= (1 << 8), /* Transmit Message */
+-	EM_CTL_MR		= (1 << 0), /* Message Received */
+-	EM_CTL_ALHD		= (1 << 26), /* Activity LED */
+-	EM_CTL_XMT		= (1 << 25), /* Transmit Only */
+-	EM_CTL_SMB		= (1 << 24), /* Single Message Buffer */
+-	EM_CTL_SGPIO		= (1 << 19), /* SGPIO messages supported */
+-	EM_CTL_SES		= (1 << 18), /* SES-2 messages supported */
+-	EM_CTL_SAFTE		= (1 << 17), /* SAF-TE messages supported */
+-	EM_CTL_LED		= (1 << 16), /* LED messages supported */
++	EM_CTL_RST		= BIT(9), /* Reset */
++	EM_CTL_TM		= BIT(8), /* Transmit Message */
++	EM_CTL_MR		= BIT(0), /* Message Received */
++	EM_CTL_ALHD		= BIT(26), /* Activity LED */
++	EM_CTL_XMT		= BIT(25), /* Transmit Only */
++	EM_CTL_SMB		= BIT(24), /* Single Message Buffer */
++	EM_CTL_SGPIO		= BIT(19), /* SGPIO messages supported */
++	EM_CTL_SES		= BIT(18), /* SES-2 messages supported */
++	EM_CTL_SAFTE		= BIT(17), /* SAF-TE messages supported */
++	EM_CTL_LED		= BIT(16), /* LED messages supported */
+ 
+ 	/* em message type */
+-	EM_MSG_TYPE_LED		= (1 << 0), /* LED */
+-	EM_MSG_TYPE_SAFTE	= (1 << 1), /* SAF-TE */
+-	EM_MSG_TYPE_SES2	= (1 << 2), /* SES-2 */
+-	EM_MSG_TYPE_SGPIO	= (1 << 3), /* SGPIO */
++	EM_MSG_TYPE_LED		= BIT(0), /* LED */
++	EM_MSG_TYPE_SAFTE	= BIT(1), /* SAF-TE */
++	EM_MSG_TYPE_SES2	= BIT(2), /* SES-2 */
++	EM_MSG_TYPE_SGPIO	= BIT(3), /* SGPIO */
+ };
+ 
+ struct ahci_cmd_hdr {
+-- 
+2.43.0
+

--- a/recipes-kernel/linux/linux-variscite_5.15.bb
+++ b/recipes-kernel/linux/linux-variscite_5.15.bb
@@ -39,7 +39,7 @@ SRCREV:imx8mn-var-som = "da2218c723da2323ae744b8ba71a93802a23f976"
 LINUX_VERSION:imx8mn-var-som = "5.15.71"
 
 SRCBRANCH:imx8mp-var-dart = "lf-5.15.y_var01"
-SRCREV:imx8mp-var-dart = "da2218c723da2323ae744b8ba71a93802a23f976"
+SRCREV:imx8mp-var-dart = "7d95b5611171d1a973b6e8d4bd65348fd982de44"
 LINUX_VERSION:imx8mp-var-dart = "5.15.71"
 
 SRCBRANCH:imx93-var-som = "lf-5.15.y_var01"

--- a/recipes-kernel/linux/linux-variscite_5.15.bb
+++ b/recipes-kernel/linux/linux-variscite_5.15.bb
@@ -29,6 +29,8 @@ LINUX_VERSION = "5.15.60"
 SRCBRANCH:imx6ul-var-dart = "lf-5.15.y_var01"
 SRCREV:imx6ul-var-dart = "ed54a5eb79177bbde3d359f92c1bf1fb7fdb1f20"
 LINUX_VERSION:imx6ul-var-dart = "5.15.71"
+SRC_URI:append:imx6ul-var-dart = " file://0001-Match-function-return-types-for-_QuerySignal.patch \
+                                   file://0001-ata-ahci-fix-enum-constants-for-gcc-13.patch"
 
 SRCBRANCH:imx7-var-som = "lf-5.15.y_var01"
 SRCREV:imx7-var-som = "ed54a5eb79177bbde3d359f92c1bf1fb7fdb1f20"

--- a/recipes-support/dnsmasq/dnsmasq_%.bbappend
+++ b/recipes-support/dnsmasq/dnsmasq_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+PACKAGECONFIG:append = " dbus"


### PR DESCRIPTION
imx6ul-var-dart is using 5.15.71 which does not have all the needed fixes to get it going with gcc-13, bring the minimum set needed for building kenrel + modules.