### PR TITLE
imx-boot: Replace BOOT_NAME with imx-boot

### DIFF
--- a/recipes-bsp/imx-mkimage/imx-boot_1.0.bbappend
+++ b/recipes-bsp/imx-mkimage/imx-boot_1.0.bbappend
@@ -30,7 +30,7 @@ do_compile:var-som() {
     for type in ${UBOOT_CONFIG}; do
         UBOOT_CONFIG_EXTRA=$type
         UBOOT_NAME_EXTRA="u-boot-${MACHINE}.bin-$type"
-        BOOT_CONFIG_MACHINE_EXTRA="${BOOT_NAME}-${MACHINE}-${UBOOT_CONFIG_EXTRA}.bin"
+        BOOT_CONFIG_MACHINE_EXTRA="imx-boot-${MACHINE}-${UBOOT_CONFIG_EXTRA}.bin"
         for target in ${IMXBOOT_TARGETS}; do
             compile_${SOC_FAMILY}
             if [ "$target" = "flash_linux_m4_no_v2x" ]; then


### PR DESCRIPTION
BOOT_NAME is gone see [1]

Fixes
install: cannot stat '/mnt/b/yoe/master/build/tmp/work/imx8qm_var_som-yoe-linux/imx-boot/1.0/git/imx-boot-imx8qm-var-som-sd.bin-flash_spl': No such file or directory

[1] https://github.com/Freescale/meta-freescale/commit/0e3a84c9d46abfd62143887ada7a58b8127ff747