### PR TITLE
firmware-nxp-wifi: Keep old file name of nxp8997 and nxp9098

### DIFF
--- a/recipes-bsp/firmware-imx/firmware-nxp-wifi_%.bbappend
+++ b/recipes-bsp/firmware-imx/firmware-nxp-wifi_%.bbappend
@@ -6,3 +6,6 @@ SRC_URI:var-som = "git://github.com/varigit/imx-firmware.git;protocol=https;bran
 SRCBRANCH:var-som = "lf-6.1.36_2.1.0-var01"
 SRCREV:var-som = "f0d834846d0d6339a73a97e7816f68b41f345b96"
 LIC_FILES_CHKSUM:var-som = "file://LICENSE.txt;md5=db4762b09b6bda63da103963e6e081de"
+
+FILES:${PN}-nxp8997-common += "${nonarch_base_libdir}/firmware/nxp/uartuart8997_bt_v4.bin"
+FILES:${PN}-nxp9098-common += "${nonarch_base_libdir}/firmware/nxp/uartuart9098_bt_v1.bin"


### PR DESCRIPTION
Latest recipe from meta-freescale has upgraded to NXP SDK 6.52-2.2.0 and these files are renamed in the new firmware, however, for Variscite we still use a fork of 6.1.36 SDK and we need to keep the old names packaged as well.

Fixes

ERROR: firmware-nxp-wifi-1.0-r0 do_package: QA Issue: firmware-nxp-wifi: Files/directories were installed but not shipped in any package:

/usr/lib/firmware/nxp/uartuart8997_bt_v4.bin
/usr/lib/firmware/nxp/uartuart9098_bt_v1.bin