### PR TITLE
libubootenv: Refresh patch to apply to latest u-boot sources

### DIFF
--- a/recipes-bsp/u-boot/libubootenv/0001-uboot_env-extend-line-length-to-4096.patch
+++ b/recipes-bsp/u-boot/libubootenv/0001-uboot_env-extend-line-length-to-4096.patch
@@ -14,8 +14,8 @@ Signed-off-by: FrancescoFerraro <francesco.f@variscite.com>
 
 --- a/src/uboot_env.c
 +++ b/src/uboot_env.c
-@@ -1409,7 +1409,7 @@ cleanup:
- 	return status;
+@@ -766,7 +766,7 @@ static int libuboot_load(struct uboot_ct
+ 	return ctx->valid ? 0 : -ENODATA;
  }
  
 -#define LINE_LENGTH 2048


### PR DESCRIPTION
Fixes patch fuzz
Applying patch 0001-uboot_env-extend-line-length-to-4096.patch patching file src/uboot_env.c
Hunk #1 succeeded at 766 with fuzz 1 (offset -643 lines).